### PR TITLE
Add spouse age and new couple distribution option

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -129,6 +129,8 @@ const PCEMSSimulator = () => {
       if (name === "repartitionCouple") {
         if (newValue === "unEnEMS" || newValue === "deuxEnEMS") {
           updated.tauxImputationFortune = "20"; // 20% par défaut pour EMS
+        } else if (newValue === "deuxADomicile") {
+          updated.tauxImputationFortune = "10"; // 10% pour un couple à domicile
         }
       }
 
@@ -211,7 +213,7 @@ const PCEMSSimulator = () => {
 
     const residenceApresAbattement = Math.max(
       0,
-      residencePrincipale - abattement
+      residencePrincipale - abattement,
     );
 
     // Règle 2025: Exonération du logement principal si fortune mobilière ≤ 200'000 CHF
@@ -297,11 +299,11 @@ const PCEMSSimulator = () => {
     const franchiseActivite = 12000;
     const revenuActiviteResidentNet = Math.max(
       0,
-      revenuActiviteResident - franchiseActivite
+      revenuActiviteResident - franchiseActivite,
     );
     const revenuActiviteConjointNet = Math.max(
       0,
-      revenuActiviteConjoint - franchiseActivite
+      revenuActiviteConjoint - franchiseActivite,
     );
 
     const revenusActiviteLucrative =
@@ -441,7 +443,7 @@ const PCEMSSimulator = () => {
     // Calcul des PC annuelles
     const pcAnnuelles = Math.max(
       0,
-      chargesCalculs.totalChargesAnnuelles - totalRevenusAvecImputation
+      chargesCalculs.totalChargesAnnuelles - totalRevenusAvecImputation,
     );
     const pcMensuelles = pcAnnuelles / 12;
 
@@ -468,7 +470,7 @@ const PCEMSSimulator = () => {
       const totalChargesReparties = chargesResident + chargesConjoint;
       if (totalChargesReparties > 0) {
         pcResident = Math.round(
-          pcAnnuelles * (chargesResident / totalChargesReparties)
+          pcAnnuelles * (chargesResident / totalChargesReparties),
         );
         pcConjoint = pcAnnuelles - pcResident; // Pour s'assurer que le total reste correct
       }
@@ -561,7 +563,7 @@ const PCEMSSimulator = () => {
       const printWindow = window.open(
         "",
         "PRINT",
-        "height=650,width=900,top=100,left=150"
+        "height=650,width=900,top=100,left=150",
       );
       if (!printWindow) {
         alert("Veuillez autoriser les pop-ups pour exporter en PDF");
@@ -772,10 +774,10 @@ const PCEMSSimulator = () => {
             <h2>Droit mensuel aux prestations complémentaires</h2>
             <div class="result-amount">${pcCalculs.pcMensuelles.toLocaleString(
               "fr-CH",
-              { minimumFractionDigits: 0, maximumFractionDigits: 0 }
+              { minimumFractionDigits: 0, maximumFractionDigits: 0 },
             )} CHF / mois</div>
             <p style="margin: 5px 0; color: #666;">soit ${pcCalculs.pcAnnuelles.toLocaleString(
-              "fr-CH"
+              "fr-CH",
             )} CHF par année</p>
           </div>
           
@@ -798,8 +800,8 @@ const PCEMSSimulator = () => {
                   formData.statutAVSAI === "avs"
                     ? "Bénéficiaire AVS"
                     : formData.statutAVSAI === "ai"
-                    ? "Bénéficiaire AI"
-                    : "Non renseigné"
+                      ? "Bénéficiaire AI"
+                      : "Non renseigné"
                 }</td>
               </tr>
               <tr>
@@ -837,7 +839,7 @@ const PCEMSSimulator = () => {
               <tr class="total-row">
                 <td class="label">Fortune prise en compte</td>
                 <td class="value">${fortuneCalculs.fortunePriseEnCompte.toLocaleString(
-                  "fr-CH"
+                  "fr-CH",
                 )} CHF</td>
               </tr>
             </table>
@@ -849,19 +851,19 @@ const PCEMSSimulator = () => {
               <tr>
                 <td class="label">Rentes AVS/AI</td>
                 <td class="value">${revenusCalculs.rentesAVSAI.toLocaleString(
-                  "fr-CH"
+                  "fr-CH",
                 )} CHF</td>
               </tr>
               <tr>
                 <td class="label">Rentes LPP</td>
                 <td class="value">${revenusCalculs.rentesLPP.toLocaleString(
-                  "fr-CH"
+                  "fr-CH",
                 )} CHF</td>
               </tr>
               <tr class="total-row">
                 <td class="label">Total des revenus annuels</td>
                 <td class="value">${revenusCalculs.totalRevenusAnnuels.toLocaleString(
-                  "fr-CH"
+                  "fr-CH",
                 )} CHF</td>
               </tr>
             </table>
@@ -873,19 +875,19 @@ const PCEMSSimulator = () => {
               <tr>
                 <td class="label">Assurance maladie</td>
                 <td class="value">${chargesCalculs.assuranceMaladie.toLocaleString(
-                  "fr-CH"
+                  "fr-CH",
                 )} CHF</td>
               </tr>
               <tr>
                 <td class="label">Besoins vitaux</td>
                 <td class="value">${chargesCalculs.besoinsVitaux.toLocaleString(
-                  "fr-CH"
+                  "fr-CH",
                 )} CHF</td>
               </tr>
               <tr class="total-row">
                 <td class="label">Total des charges annuelles</td>
                 <td class="value">${chargesCalculs.totalChargesAnnuelles.toLocaleString(
-                  "fr-CH"
+                  "fr-CH",
                 )} CHF</td>
               </tr>
             </table>
@@ -913,7 +915,7 @@ const PCEMSSimulator = () => {
     } catch (error) {
       console.error("Erreur lors de l'export PDF:", error);
       alert(
-        "Une erreur est survenue lors de l'export PDF. Veuillez réessayer."
+        "Une erreur est survenue lors de l'export PDF. Veuillez réessayer.",
       );
     }
   };

--- a/src/PCEMSPage1.js
+++ b/src/PCEMSPage1.js
@@ -37,16 +37,22 @@ const regionsOfas = [
 
 const statuts = ["Bénéficiaire AVS", "Bénéficiaire AI"];
 
-const cantons = [ /* ... */ ];
-const regionsOfas = [ /* ... */ ];
-const statuts = [ /* ... */ ];
+const cantons = [
+  /* ... */
+];
+const regionsOfas = [
+  /* ... */
+];
+const statuts = [
+  /* ... */
+];
 
 export default function PCEMSPage1({ formData = {}, handleInputChange }) {
   const [situationCouple, setSituationCouple] = useState(
-    formData.situationCouple || "avecConjoint"
+    formData.situationCouple || "avecConjoint",
   );
   const [repartitionCouple, setRepartitionCouple] = useState(
-    formData.repartitionCouple || "unEnEMS"
+    formData.repartitionCouple || "unEnEMS",
   );
 
   return (
@@ -155,26 +161,26 @@ export default function PCEMSPage1({ formData = {}, handleInputChange }) {
         <div style={{ display: "flex", gap: 32 }}>
           {/* Colonne 1 */}
           <div style={{ flex: 1 }}>
-          <label style={{ fontWeight: 500 }}>Canton de domicile</label>
-          <select style={selectStyle}>
-            <option value="">Sélectionnez un canton</option>
-            {cantons.map((c) => (
-              <option key={c} value={c}>
-                {c}
-              </option>
-            ))}
-          </select>
-          <label style={{ fontWeight: 500, marginTop: 20, display: "block" }}>
-            Statut AVS/AI
-          </label>
-          <select style={selectStyle}>
-            <option value="">Sélectionnez un statut</option>
-            {statuts.map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
+            <label style={{ fontWeight: 500 }}>Canton de domicile</label>
+            <select style={selectStyle}>
+              <option value="">Sélectionnez un canton</option>
+              {cantons.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+            <label style={{ fontWeight: 500, marginTop: 20, display: "block" }}>
+              Statut AVS/AI
+            </label>
+            <select style={selectStyle}>
+              <option value="">Sélectionnez un statut</option>
+              {statuts.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
             <div style={{ marginTop: 20 }}>
               <label style={{ fontWeight: 500 }}>Situation de couple</label>
               <div style={{ marginTop: 8 }}>
@@ -205,7 +211,9 @@ export default function PCEMSPage1({ formData = {}, handleInputChange }) {
               </div>
               {situationCouple === "avecConjoint" && (
                 <div style={{ marginTop: 12 }}>
-                  <label style={{ fontWeight: 500 }}>Répartition du couple</label>
+                  <label style={{ fontWeight: 500 }}>
+                    Répartition du couple
+                  </label>
                   <select
                     name="repartitionCouple"
                     value={repartitionCouple}
@@ -215,8 +223,9 @@ export default function PCEMSPage1({ formData = {}, handleInputChange }) {
                     }}
                     style={selectStyle}
                   >
-                    <option value="unEnEMS">Un conjoint en EMS</option>
+                    <option value="unEnEMS">Un en EMS, un à domicile</option>
                     <option value="deuxEnEMS">Les deux en EMS</option>
+                    <option value="deuxADomicile">Les deux à domicile</option>
                   </select>
                 </div>
               )}
@@ -224,21 +233,43 @@ export default function PCEMSPage1({ formData = {}, handleInputChange }) {
           </div>
           {/* Colonne 2 */}
           <div style={{ flex: 1 }}>
-          <label style={{ fontWeight: 500 }}>
-            Région de loyer (selon l'OFAS)
-          </label>
-          <select style={selectStyle}>
-            <option value="">Sélectionnez une région</option>
-            {regionsOfas.map((r) => (
-              <option key={r} value={r}>
-                {r}
-              </option>
-            ))}
-          </select>
+            <label style={{ fontWeight: 500 }}>
+              Région de loyer (selon l'OFAS)
+            </label>
+            <select style={selectStyle}>
+              <option value="">Sélectionnez une région</option>
+              {regionsOfas.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
             <label style={{ fontWeight: 500, marginTop: 20, display: "block" }}>
               Âge du résident EMS
             </label>
-            <input type="number" value={70} style={inputStyle} />
+            <input
+              type="number"
+              name="ageResident"
+              value={formData.ageResident || ""}
+              onChange={handleInputChange}
+              style={inputStyle}
+            />
+            {situationCouple === "avecConjoint" && (
+              <>
+                <label
+                  style={{ fontWeight: 500, marginTop: 20, display: "block" }}
+                >
+                  Âge du conjoint
+                </label>
+                <input
+                  type="number"
+                  name="ageConjoint"
+                  value={formData.ageConjoint || ""}
+                  onChange={handleInputChange}
+                  style={inputStyle}
+                />
+              </>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- expand repartitionCouple select with new option for both spouses at home
- capture age of resident and spouse on the first page
- adjust default fortune rate when selecting couple at home
- run prettier on modified files

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435ff047248324a7679badb1df344b